### PR TITLE
Refactor/assembler/refactor errors and opcode mapping

### DIFF
--- a/assembler/assembler
+++ b/assembler/assembler
@@ -4,6 +4,7 @@ import sys
 import assembly_service
 from reader import Reader
 from writer import Writer
+from errors import AsmError
 
 
 def main(argv):
@@ -11,9 +12,18 @@ def main(argv):
         raise SystemExit("Usage: assembler <file.asm>")
 
     asm_path = argv[0]
-    lines = Reader.read_lines(asm_path)
-
-    stmts, symbols_table, binaries = assembly_service.assemble_lines(lines)
+    
+    try:
+        lines = Reader.read_lines(asm_path)
+        stmts, symbols_table, binaries = assembly_service.assemble_lines(lines)
+    except AsmError as e:
+        # User-facing error: print friendly message without stack trace
+        print(f"Assembler Error: {e}", file=sys.stderr)
+        sys.exit(1)
+    except Exception as e:
+        # Internal/unexpected error: print with context for debugging
+        print(f"Internal Error: {e}", file=sys.stderr)
+        sys.exit(2)
 
     lst_text = Writer.build_listing(lines, stmts, symbols_table)
 

--- a/assembler/errors.py
+++ b/assembler/errors.py
@@ -1,0 +1,37 @@
+"""Domain-specific exception hierarchy for the assembler.
+
+Provides meaningful exception types to distinguish between:
+- User-facing syntax errors (AsmSyntaxError)
+- Semantic/validation errors (AsmSemanticError)
+- Programming logic errors (AsmInternalError)
+"""
+
+
+class AsmError(Exception):
+    """Base exception for all assembler domain errors."""
+
+    def __init__(self, message: str, line: int | None = None):
+        self.message = message
+        self.line = line
+        if line is not None:
+            super().__init__(f"Line {line}: {message}")
+        else:
+            super().__init__(message)
+
+
+class AsmSyntaxError(AsmError):
+    """Raised when assembly syntax is invalid (wrong number of arguments, wrong argument types, etc.)."""
+
+    pass
+
+
+class AsmSemanticError(AsmError):
+    """Raised when assembly is syntactically correct but semantically invalid (undefined labels, invalid values, etc.)."""
+
+    pass
+
+
+class AsmInternalError(AsmError):
+    """Raised for internal assembler errors that indicate programmer bugs, not user errors."""
+
+    pass

--- a/assembler/statements.py
+++ b/assembler/statements.py
@@ -1,8 +1,5 @@
 import tokens as Tokens
-
-class StmtError(Exception):
-    def __init__(self, message):
-        super().__init__(message)
+from errors import AsmError, AsmSyntaxError, AsmSemanticError
 
 class Statement:
     def __init__(self, tokens, symbols_table):
@@ -15,7 +12,7 @@ class Statement:
         address = self.symbols_table.get(label, False)
         if address:
             return f"#{address['address'] - self.addr - 1}"
-        raise StmtError(f"Undefined Label '{label}' used on line {self.line}.")
+        raise AsmSemanticError(f"Undefined Label '{label}' used.", self.line)
 
     def resolve(self):
         return f"{0:016b}"
@@ -35,13 +32,13 @@ class Arithmetic(Statement):
         tokens = self.tokens
         size = len(tokens)
         if size != 4:
-            raise Exception(f"Error on line {self.line}: Operation takes 3 arguments, {size} found.")
+            raise AsmSyntaxError(f"Operation takes 3 arguments, {size} found.", self.line)
 
         if isinstance(tokens[3], Tokens.Register):
             return tokens[0].to_bin(4) + tokens[1].to_bin(3) + tokens[2].to_bin(3) + "000" + tokens[3].to_bin(3)
         if isinstance(tokens[3], Tokens.Number):
             return tokens[0].to_bin(4) + tokens[1].to_bin(3) + tokens[2].to_bin(3) + "1" + tokens[3].to_bin(5)
-        raise Exception(f"Error on line {self.line}: Operation takes either a Number or a Register as last argument.")
+        raise AsmSyntaxError(f"Operation takes either a Number or a Register as last argument.", self.line)
 
 class Directive(Statement):
     @classmethod
@@ -54,13 +51,13 @@ class Directive(Statement):
         if size == 1 and tokens[0].lexeme == ".END":
             return ""
         if size != 2:
-            raise Exception(f"Error on line {self.line}: directive takes one value, {size-1} found.")
+            raise AsmSyntaxError(f"Directive takes one value, {size-1} found.", self.line)
 
         if tokens[0].lexeme == '.BLKW':
             return [f"{0:016b}"] * tokens[-1].to_int()
         if isinstance(tokens[1], Tokens.Number) or isinstance(tokens[1], Tokens.String):
             return tokens[1].to_bin(16)
-        raise Exception(f"Error on line {self.line}: directive only takes a `Literal` argument.")
+        raise AsmSyntaxError(f"Directive only takes a Literal argument.", self.line)
 
 class Branch(Statement):
     @classmethod
@@ -72,9 +69,9 @@ class Branch(Statement):
         size = len(tokens)
 
         if size != 2:
-            raise Exception(f"Error on line {self.line}: Operation takes 1 argument, {size-1} found.")
+            raise AsmSyntaxError(f"Operation takes 1 argument, {size-1} found.", self.line)
         if not isinstance(tokens[1], Tokens.Label) and not isinstance(tokens[1], Tokens.Number):
-            raise Exception(f"Error on line {self.line}: Operation only takes a `Label` or `Number` argument.")
+            raise AsmSyntaxError(f"Operation only takes a Label or Number argument.", self.line)
 
         tokens = [Tokens.Number(self.label_addr(t.lexeme), t.line) if isinstance(t, Tokens.Label) else t for t in tokens]
         if tokens[0].lexeme == "BR":
@@ -96,11 +93,11 @@ class Jump(Statement):
 
         if tokens[0].lexeme == "RET":
             if size != 1:
-                raise Exception(f"Error on line {self.line}: Operation takes no argument.")
+                raise AsmSyntaxError(f"Operation takes no argument.", self.line)
             return tokens[0].to_bin(4) + "000" + "111" + "000000"
 
         if size != 2:
-            raise Exception(f"Error on line {self.line}: Operation takes 1 argument, {size-1} found.")
+            raise AsmSyntaxError(f"Operation takes 1 argument, {size-1} found.", self.line)
 
         if isinstance(tokens[1], Tokens.Label):
             flag = "1"
@@ -122,13 +119,13 @@ class Load(Statement):
 
         if tokens[0].lexeme == "LDR":
             if size != 4:
-                raise Exception(f"Error on line {self.line}: Operation takes 3 arguments, {size-1} found.")
+                raise AsmSyntaxError(f"Operation takes 3 arguments, {size-1} found.", self.line)
             return tokens[0].to_bin(4) + tokens[1].to_bin(3) + tokens[2].to_bin(3) + tokens[3].to_bin(6)
 
         tokens = [Tokens.Number(self.label_addr(t.lexeme), t.line) if isinstance(t, Tokens.Label) else t for t in tokens]
 
         if size != 3:
-            raise Exception(f"Error on line {self.line}: Operation takes 2 arguments, {size-1} found.")
+            raise AsmSyntaxError(f"Operation takes 2 arguments, {size-1} found.", self.line)
         return tokens[0].to_bin(4) + tokens[1].to_bin(3) + tokens[2].to_bin(9, True)
 
 class Logical(Statement):
@@ -142,10 +139,10 @@ class Logical(Statement):
 
         if tokens[0].lexeme == "NOT":
             if size != 3:
-                raise Exception(f"Error on line {self.line}: Operation takes 2 arguments, {size-1} found.")
+                raise AsmSyntaxError(f"Operation takes 2 arguments, {size-1} found.", self.line)
             return tokens[0].to_bin(4) + tokens[1].to_bin(3) + tokens[2].to_bin(3) + "111111"
         if size != 4:
-            raise Exception(f"Error on line {self.line}: Operation takes 3 arguments, {size-1} found.")
+            raise AsmSyntaxError(f"Operation takes 3 arguments, {size-1} found.", self.line)
         if isinstance(tokens[-1], Tokens.Register):
             flag = "0"
             offset = "00" + tokens[-1].to_bin(3)
@@ -165,11 +162,11 @@ class Store(Statement):
 
         if tokens[0].lexeme == "STR":
             if size != 4:
-                raise Exception(f"Error on line {self.line}: Operation takes 3 arguments, {size-1} found.")
+                raise AsmSyntaxError(f"Operation takes 3 arguments, {size-1} found.", self.line)
             return tokens[0].to_bin(4) + tokens[1].to_bin(3) + tokens[2].to_bin(3) + tokens[3].to_bin(6)
 
         if size != 3:
-            raise Exception(f"Error on line {self.line}: Operation takes 2 arguments, {size-1} found.")
+            raise AsmSyntaxError(f"Operation takes 2 arguments, {size-1} found.", self.line)
         laddr = Tokens.Number(self.label_addr(tokens[2].lexeme), self.line)
         return tokens[0].to_bin(4) + tokens[1].to_bin(3) + laddr.to_bin(9, True)
 
@@ -182,7 +179,7 @@ class Trap(Statement):
         tokens = self.tokens
         size = len(tokens)
         if size > 1:
-            raise Exception(f"Error on line {self.line}: Operation does not take arguments, {size-1} found.")
+            raise AsmSyntaxError(f"Operation does not take arguments, {size-1} found.", self.line)
         opcode = tokens[0].to_bin(4)
         match tokens[0].lexeme:
             case "GETC":

--- a/assembler/tests/test_integration.py
+++ b/assembler/tests/test_integration.py
@@ -1,6 +1,7 @@
 """Integration tests for the full assembly pipeline."""
 import pytest
 import statements
+from errors import AsmSemanticError
 from tests.conftest import run_pipeline
 
 
@@ -202,7 +203,7 @@ class TestErrorCases:
 
         result = run_pipeline(lines)
         # Should raise error when resolving
-        with pytest.raises(statements.StmtError) as exc_info:
+        with pytest.raises(AsmSemanticError) as exc_info:
             result.stmts[1].resolve()
         assert "Undefined Label" in str(exc_info.value)
 

--- a/assembler/tests/test_statements.py
+++ b/assembler/tests/test_statements.py
@@ -2,6 +2,7 @@
 import pytest
 import statements
 import tokens
+from errors import AsmSyntaxError, AsmSemanticError
 
 
 # Independent opcode oracle for tests (do NOT derive from production code).
@@ -190,9 +191,9 @@ class TestDirective:
         ]
         stmt = statements.Directive(toks, {})
 
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(AsmSyntaxError) as exc_info:
             stmt.resolve()
-        assert "only takes a `Literal` argument" in str(exc_info.value)
+        assert "only takes a Literal argument" in str(exc_info.value)
 
 
 class TestBranch:
@@ -324,9 +325,9 @@ class TestBranch:
         ]
         stmt = statements.Branch(toks, {})
 
-        with pytest.raises(Exception) as exc_info:
+        with pytest.raises(AsmSyntaxError) as exc_info:
             stmt.resolve()
-        assert "only takes a `Label` or `Number` argument" in str(exc_info.value)
+        assert "only takes a Label or Number argument" in str(exc_info.value)
 
 
 class TestJump:
@@ -683,7 +684,7 @@ class TestStatementBase:
         stmt = statements.Statement(toks, {})
         stmt.addr = 0x3000
 
-        with pytest.raises(statements.StmtError) as exc_info:
+        with pytest.raises(AsmSemanticError) as exc_info:
             stmt.label_addr("UNDEFINED")
         assert "Undefined Label" in str(exc_info.value)
 

--- a/assembler/tokens.py
+++ b/assembler/tokens.py
@@ -73,11 +73,18 @@ OPERATIONS = {
     # TRAP
     "TRAP": { "GETC": "1111", "OUT": "1111", "IN": "1111", "PUTS": "1111", "HALT": "1111" }
 }
+
+# Precompute flat lookup structures at module load time
+OPCODE_MAP = {op: code for category in OPERATIONS.values() for op, code in category.items()}
+OPERATION_SET = set(OPCODE_MAP.keys())
+
 class Operation(Token):
     @classmethod
     def match(cls, lexeme):
-        return lexeme in [x for xs in list(OPERATIONS.values()) for (x, _) in xs.items()]
+        return lexeme in OPERATION_SET
 
     def to_bin(self, size):
-        value = dict([x for xs in list(OPERATIONS.values()) for x in xs.items()])[self.lexeme]
+        if self.lexeme not in OPCODE_MAP:
+            raise ValueError(f"Unknown operation: {self.lexeme}")
+        value = OPCODE_MAP[self.lexeme]
         return f"{int(value, 2):0{size}b}"


### PR DESCRIPTION
# Description

This PR closes #10 and #12 by:
- Refactor the Error handling by renaming the errors and extracting them into a new `errors.py` file and change unit tests accordingly.
- Refactor the OpCode mapping and pre-compute those into a Set to reduce access time to 0(1).