### PR TITLE
Refactor Add a  module for different outputs

### DIFF
--- a/assembler/assembler
+++ b/assembler/assembler
@@ -4,6 +4,7 @@ import sys
 import assembly_service
 from reader import Reader
 from writer import Writer
+from presenters import ListingPresenter, SymbolPresenter, BinaryPresenter
 from errors import AsmError
 
 
@@ -25,19 +26,25 @@ def main(argv):
         print(f"Internal Error: {e}", file=sys.stderr)
         sys.exit(2)
 
-    lst_text = Writer.build_listing(lines, stmts, symbols_table)
+    # Format outputs using presenters
+    lst_text = ListingPresenter.format_listing(lines, stmts, symbols_table)
+    sym_lines = SymbolPresenter.format_symbol_lines(symbols_table)
+    bin_lines = BinaryPresenter.format_binary_lines(binaries)
+    hex_lines = BinaryPresenter.format_hex_lines(binaries)
 
+    # Prepare output paths
     obj_path = asm_path.replace(".asm", ".obj")
     sym_path = asm_path.replace(".asm", ".sym")
     lst_path = asm_path.replace(".asm", ".lst")
     bin_path = asm_path.replace(".asm", ".bin")
     hex_path = asm_path.replace(".asm", ".hex")
 
+    # Write output files
     Writer.write_obj(obj_path, binaries)
-    Writer.write_txt(sym_path, [f"{label:20}{' ':10}x{meta['address']:04X}\n" for label, meta in symbols_table.items()])
+    Writer.write_txt(sym_path, sym_lines)
     Writer.write_txt(lst_path, lst_text)
-    Writer.write_txt(bin_path, [f"{x}\n" for x in binaries])
-    Writer.write_txt(hex_path, [f"{int(x, 2):04X}\n" for x in binaries])
+    Writer.write_txt(bin_path, bin_lines)
+    Writer.write_txt(hex_path, hex_lines)
 
 
 if __name__ == "__main__":

--- a/assembler/assembler
+++ b/assembler/assembler
@@ -4,7 +4,7 @@ import sys
 import assembly_service
 from reader import Reader
 from writer import Writer
-from presenters import ListingPresenter, SymbolPresenter, BinaryPresenter
+from formatters import ListingFormatter, SymbolFormatter, BinaryFormatter, HexFormatter
 from errors import AsmError
 
 
@@ -13,7 +13,7 @@ def main(argv):
         raise SystemExit("Usage: assembler <file.asm>")
 
     asm_path = argv[0]
-    
+
     try:
         lines = Reader.read_lines(asm_path)
         stmts, symbols_table, binaries = assembly_service.assemble_lines(lines)
@@ -26,11 +26,17 @@ def main(argv):
         print(f"Internal Error: {e}", file=sys.stderr)
         sys.exit(2)
 
-    # Format outputs using presenters
-    lst_text = ListingPresenter.format_listing(lines, stmts, symbols_table)
-    sym_lines = SymbolPresenter.format_symbol_lines(symbols_table)
-    bin_lines = BinaryPresenter.format_binary_lines(binaries)
-    hex_lines = BinaryPresenter.format_hex_lines(binaries)
+    # Create formatter instances
+    listing_formatter = ListingFormatter()
+    symbol_formatter = SymbolFormatter()
+    binary_formatter = BinaryFormatter()
+    hex_formatter = HexFormatter()
+
+    # Format outputs using formatters
+    lst_text = listing_formatter.format(lines, stmts, symbols_table)
+    sym_lines = symbol_formatter.format(symbols_table)
+    bin_lines = binary_formatter.format(binaries)
+    hex_lines = hex_formatter.format(binaries)
 
     # Prepare output paths
     obj_path = asm_path.replace(".asm", ".obj")

--- a/assembler/formatters.py
+++ b/assembler/formatters.py
@@ -1,16 +1,32 @@
-"""Presenters module for formatting assembler output.
+"""Formatters module for formatting assembler output.
 
 Separates domain logic from presentation concerns. Provides formatters that
 transform assembly results into view models or strings for various output formats
 (.lst, .sym, .bin, .hex).
+
+Uses a Formatter interface pattern where each formatter implements a format() method.
 """
 
+from abc import ABC, abstractmethod
 
-class SymbolPresenter:
+
+class Formatter(ABC):
+    """Abstract base class for output formatters."""
+
+    @abstractmethod
+    def format(self, *args, **kwargs):
+        """Format the input into output lines for file writing.
+
+        Returns:
+            List[str] of formatted lines ready for output
+        """
+        pass
+
+
+class SymbolFormatter(Formatter):
     """Formats symbol table for .sym file output."""
 
-    @staticmethod
-    def format_symbol_lines(symbols_table):
+    def format(self, symbols_table):
         """Format symbol table as lines for .sym file.
 
         Args:
@@ -25,11 +41,10 @@ class SymbolPresenter:
         ]
 
 
-class BinaryPresenter:
-    """Formats binary data for .bin and .hex file outputs."""
+class BinaryFormatter(Formatter):
+    """Formats binary data for .bin file output."""
 
-    @staticmethod
-    def format_binary_lines(binaries):
+    def format(self, binaries):
         """Format binary strings for .bin file.
 
         Args:
@@ -40,8 +55,11 @@ class BinaryPresenter:
         """
         return [f"{b}\n" for b in binaries]
 
-    @staticmethod
-    def format_hex_lines(binaries):
+
+class HexFormatter(Formatter):
+    """Formats binary data as hex for .hex file output."""
+
+    def format(self, binaries):
         """Format binary strings as hex for .hex file.
 
         Args:
@@ -53,11 +71,10 @@ class BinaryPresenter:
         return [f"{int(b, 2):04X}\n" for b in binaries]
 
 
-class ListingPresenter:
+class ListingFormatter(Formatter):
     """Formats assembly listing table for .lst file output."""
 
-    @staticmethod
-    def format_listing(lines, stmts, symbols_table):
+    def format(self, lines, stmts, symbols_table):
         """Format a detailed listing table from assembly lines and statements.
 
         Domain-agnostic: takes parsed results and produces a formatted view.

--- a/assembler/pre_parsers.py
+++ b/assembler/pre_parsers.py
@@ -20,33 +20,201 @@ def has_end(tokenized_lines):
         return True
     raise PreParsingError("Last line must be a '.END' Directive.")
 
-def symbols(tokenized_lines, origin):
-    labels = []
-    idx = 0
-    for line in tokenized_lines:
-        if line[0].lexeme in [".ORIG", ".END"]:
-            continue
-        for t in line:
-            t.addr = origin + idx
+
+# Address Calculation: Pure, focused functions with clear responsibility
+def _should_skip_address_increment(line):
+    """Check if a line should not increment the address counter.
+
+    Label-only lines do not consume memory; they just mark an address.
+
+    Args:
+        line: List of tokens for a source line
+
+    Returns:
+        bool: True if address should not increment for this line
+    """
+    # Label-only line: label without any instruction/directive
+    return len(line) == 1 and isinstance(line[0], tokens.Label)
+
+
+def _get_line_size(line):
+    """Compute memory size (in words) consumed by a line.
+
+    Rules:
+    - .STRINGZ directive: size = string length (including null terminator)
+    - .BLKW directive: size = block size
+    - .ORIG and .END: size = 0 (no memory consumed)
+    - Other instructions/directives: size = 1
+    - Label-only lines: size = 0
+
+    Args:
+        line: List of tokens for a source line
+
+    Returns:
+        int: Number of words this line consumes
+    """
+    if not line:
+        return 0
+
+    # Check for directives that should be skipped
+    if line[0].lexeme in [".ORIG", ".END"]:
+        return 0
+
+    # Label-only line consumes no space
+    if _should_skip_address_increment(line):
+        return 0
+
+    # Check for .STRINGZ directive (string length + null terminator)
+    if len(line) > 1 and isinstance(line[1], tokens.Directive) and line[1].lexeme == ".STRINGZ":
         if isinstance(line[-1], tokens.String):
-            idx += len(re.sub(r'\\n', "\n", line[-1].lexeme.replace('"', '')))
+            # Remove quotes and process escape sequences to get true length
+            string_content = line[-1].lexeme.replace('"', '')
+            string_content = re.sub(r'\\n', "\n", string_content)
+            string_content = re.sub(r'\\e', "\033", string_content)
+            return len(string_content) + 1  # +1 for null terminator
+
+    # Check for .BLKW directive (block of words)
+    if len(line) > 1 and isinstance(line[1], tokens.Directive) and line[1].lexeme == ".BLKW":
+        if isinstance(line[-1], tokens.Number):
+            return line[-1].to_int()
+
+    # Default: normal instruction/directive consumes 1 word
+    return 1
+
+
+def _compute_line_addresses(tokenized_lines, origin):
+    """Compute memory address for each token line.
+
+    Pure function that computes addresses without mutating state.
+    Addresses start at `origin` and increment by line size.
+
+    Args:
+        tokenized_lines: List[List[Token]] of tokenized source lines
+        origin: Starting memory address (from .ORIG)
+
+    Returns:
+        List[int] where result[i] is the memory address for line i
+    """
+    addresses = []
+    current_addr = origin
+
+    for line in tokenized_lines:
+        addresses.append(current_addr)
+
+        # Increment address by line size (unless label-only)
+        line_size = _get_line_size(line)
+        if not _should_skip_address_increment(line):
+            current_addr += line_size
+        else:
+            # Label-only lines don't increment address; they just mark it
+            pass
+
+    return addresses
+
+
+def _extract_labels(tokenized_lines, addresses):
+    """Extract labels and their addresses from tokenized lines.
+
+    Pure function that builds a list of (label_token, address, line_number) tuples.
+
+    Args:
+        tokenized_lines: List[List[Token]] of tokenized source lines
+        addresses: List[int] of addresses for each line
+
+    Returns:
+        List[(label_token, address, line_num)]
+    """
+    label_info = []
+
+    for line_idx, line in enumerate(tokenized_lines):
+        if not line:
+            continue
+
+        # First token might be a label
         if isinstance(line[0], tokens.Label):
-            label = line[0]
-            if len(line) == 1:
-                idx -= 1
-            elif isinstance(line[1], tokens.Directive) and line[1].lexeme == ".BLKW":
-                idx += line[-1].to_int() - 1
-            labels.append(label)
-        idx += 1
+            label_token = line[0]
+            line_num = label_token.line
+            address = addresses[line_idx]
+            label_info.append((label_token, address, line_num))
 
+    return label_info
+
+
+def _build_symbol_table(label_info):
+    """Build symbol table from extracted labels, checking for duplicates.
+
+    Pure function that transforms label info into a symbol table dictionary.
+
+    Args:
+        label_info: List[(label_token, address, line_num)] from _extract_labels
+
+    Returns:
+        Dict[str, {address, line}]
+
+    Raises:
+        PreParsingError: If duplicate labels found
+    """
     result = {}
-    for label in labels:
-        if result.get(label.lexeme, False):
-            line = result[label.lexeme]['line']
-            raise PreParsingError(f"Duplicate '{label.lexeme}' Label on lines {line} and {label.line}.")
 
-        result[label.lexeme] = { 'line': label.line, 'address': label.addr } 
+    for label_token, address, line_num in label_info:
+        lexeme = label_token.lexeme
+
+        if lexeme in result:
+            existing_line = result[lexeme]['line']
+            raise PreParsingError(
+                f"Duplicate '{lexeme}' Label on lines {existing_line} and {line_num}."
+            )
+
+        result[lexeme] = {'line': line_num, 'address': address}
+
     return result
+
+
+def _annotate_token_addresses(tokenized_lines, addresses):
+    """Annotate tokens with memory addresses (mutation side-effect).
+
+    Assigns the computed address to each token in place.
+    This is intentionally separated from address computation for clarity
+    and to allow testing without side effects.
+
+    Args:
+        tokenized_lines: List[List[Token]] - will be mutated
+        addresses: List[int] of computed addresses
+    """
+    for line_idx, line in enumerate(tokenized_lines):
+        for token in line:
+            token.addr = addresses[line_idx]
+
+
+def symbols(tokenized_lines, origin):
+    """Build symbol table from tokenized lines.
+
+    Orchestrates pure functions to:
+    1. Compute addresses for each line
+    2. Extract and validate labels
+    3. Build symbol table
+    4. Annotate tokens with addresses
+
+    Args:
+        tokenized_lines: List[List[Token]] of tokenized source lines
+        origin: Starting memory address (from .ORIG)
+
+    Returns:
+        Dict[str, {address, line}] - symbol table mapping labels to info
+    """
+    # 1. Compute line addresses (pure)
+    addresses = _compute_line_addresses(tokenized_lines, origin)
+
+    # 2. Extract labels (pure)
+    label_info = _extract_labels(tokenized_lines, addresses)
+
+    # 3. Build and validate symbol table (pure)
+    symbol_table = _build_symbol_table(label_info)
+
+    # 4. Annotate tokens with addresses (side-effect, done last)
+    _annotate_token_addresses(tokenized_lines, addresses)
+
+    return symbol_table
 
 def remove_symbols(tokenized_lines):
     lines = [t[1:] if isinstance(t[0], tokens.Label) else t for t in [l for l in tokenized_lines]]

--- a/assembler/presenters.py
+++ b/assembler/presenters.py
@@ -12,10 +12,10 @@ class SymbolPresenter:
     @staticmethod
     def format_symbol_lines(symbols_table):
         """Format symbol table as lines for .sym file.
-        
+
         Args:
             symbols_table: Dict[label -> {address, line}]
-            
+
         Returns:
             List[str] of formatted symbol lines
         """
@@ -31,10 +31,10 @@ class BinaryPresenter:
     @staticmethod
     def format_binary_lines(binaries):
         """Format binary strings for .bin file.
-        
+
         Args:
             binaries: List[str] of 16-bit binary strings
-            
+
         Returns:
             List[str] of formatted binary lines
         """
@@ -43,10 +43,10 @@ class BinaryPresenter:
     @staticmethod
     def format_hex_lines(binaries):
         """Format binary strings as hex for .hex file.
-        
+
         Args:
             binaries: List[str] of 16-bit binary strings
-            
+
         Returns:
             List[str] of formatted hex lines
         """
@@ -59,14 +59,14 @@ class ListingPresenter:
     @staticmethod
     def format_listing(lines, stmts, symbols_table):
         """Format a detailed listing table from assembly lines and statements.
-        
+
         Domain-agnostic: takes parsed results and produces a formatted view.
-        
+
         Args:
             lines: Original assembly source lines
             stmts: List of parsed Statement objects
             symbols_table: Dict[label -> {address, line}]
-            
+
         Returns:
             List[str] of formatted listing lines
         """
@@ -91,7 +91,7 @@ class ListingPresenter:
             # Get address and binary representation
             addr = f"x{stmt.addr:04X}" if stmt and stmt.addr is not None else ""
             binary = stmt.resolve() if stmt else ""
-            
+
             # Handle multi-word results (e.g., .BLKW)
             long_binary = isinstance(binary, list)
             rest = []

--- a/assembler/presenters.py
+++ b/assembler/presenters.py
@@ -1,0 +1,128 @@
+"""Presenters module for formatting assembler output.
+
+Separates domain logic from presentation concerns. Provides formatters that
+transform assembly results into view models or strings for various output formats
+(.lst, .sym, .bin, .hex).
+"""
+
+
+class SymbolPresenter:
+    """Formats symbol table for .sym file output."""
+
+    @staticmethod
+    def format_symbol_lines(symbols_table):
+        """Format symbol table as lines for .sym file.
+        
+        Args:
+            symbols_table: Dict[label -> {address, line}]
+            
+        Returns:
+            List[str] of formatted symbol lines
+        """
+        return [
+            f"{label:20}{' ':10}x{meta['address']:04X}\n"
+            for label, meta in symbols_table.items()
+        ]
+
+
+class BinaryPresenter:
+    """Formats binary data for .bin and .hex file outputs."""
+
+    @staticmethod
+    def format_binary_lines(binaries):
+        """Format binary strings for .bin file.
+        
+        Args:
+            binaries: List[str] of 16-bit binary strings
+            
+        Returns:
+            List[str] of formatted binary lines
+        """
+        return [f"{b}\n" for b in binaries]
+
+    @staticmethod
+    def format_hex_lines(binaries):
+        """Format binary strings as hex for .hex file.
+        
+        Args:
+            binaries: List[str] of 16-bit binary strings
+            
+        Returns:
+            List[str] of formatted hex lines
+        """
+        return [f"{int(b, 2):04X}\n" for b in binaries]
+
+
+class ListingPresenter:
+    """Formats assembly listing table for .lst file output."""
+
+    @staticmethod
+    def format_listing(lines, stmts, symbols_table):
+        """Format a detailed listing table from assembly lines and statements.
+        
+        Domain-agnostic: takes parsed results and produces a formatted view.
+        
+        Args:
+            lines: Original assembly source lines
+            stmts: List of parsed Statement objects
+            symbols_table: Dict[label -> {address, line}]
+            
+        Returns:
+            List[str] of formatted listing lines
+        """
+        # Invert symbols: address -> label for quick lookup
+        addr_to_label = {
+            f"x{v['address']:04X}": k
+            for k, v in symbols_table.items()
+        }
+
+        # Build table rows: [ADDR, HEX, BINARY, LABEL, LINE, CODE]
+        table = [["ADDR", "HEX", "BINARY", "LABEL", "LINE", "CODE"]]
+        stmt_idx = 0
+
+        for idx, line in enumerate(lines):
+            line_num = idx + 1
+
+            # Find corresponding statement for this source line
+            stmt = None
+            if stmt_idx < len(stmts) and stmts[stmt_idx].line == line_num:
+                stmt = stmts[stmt_idx]
+
+            # Get address and binary representation
+            addr = f"x{stmt.addr:04X}" if stmt and stmt.addr is not None else ""
+            binary = stmt.resolve() if stmt else ""
+            
+            # Handle multi-word results (e.g., .BLKW)
+            long_binary = isinstance(binary, list)
+            rest = []
+            if long_binary:
+                binary, *rest = binary
+
+            hexa = f"x{int(binary, 2):04X}" if binary else ""
+            label = addr_to_label.get(addr, "")
+
+            if stmt:
+                stmt_idx += 1
+
+            # Add main row
+            table.append([addr, hexa, binary, label, line_num, line])
+
+            # Add overflow rows for multi-word statements
+            if long_binary and stmt and stmt.addr is not None:
+                a = stmt.addr + 1
+                for b in rest:
+                    table.append([
+                        f"x{int(a):04X}",
+                        f"x{int(b, 2):04X}",
+                        b,
+                        "",
+                        "",
+                        ""
+                    ])
+                    a += 1
+
+        # Format rows as text with aligned columns
+        return [
+            "{0:6}| {1:6}| {2:16}| {3:20}| {4:4}| {5:}\n".format(*row)
+            for row in table
+        ]

--- a/assembler/reader.py
+++ b/assembler/reader.py
@@ -7,10 +7,10 @@ class Reader:
     @staticmethod
     def read_lines(filename):
         """Read lines from an assembly file, stripping newlines.
-        
+
         Args:
             filename: Path to assembly file
-            
+
         Returns:
             List of source lines with newlines removed
         """

--- a/assembler/tests/test_assembler.py
+++ b/assembler/tests/test_assembler.py
@@ -13,15 +13,15 @@ class TestWriteObj:
         """Test Writer.write_obj with big endian byte order."""
         with tempfile.NamedTemporaryFile(delete=False, suffix=".obj") as f:
             filename = f.name
-        
+
         try:
             # Binary string "0000000000000001" (value 1)
             binaries = ["0000000000000001"]
             Writer.write_obj(filename, binaries, byteorder="big")
-            
+
             with open(filename, "rb") as f:
                 data = f.read()
-            
+
             # Should be 2 bytes: 0x00 0x01 in big endian
             assert len(data) == 2
             assert data == b"\x00\x01"
@@ -33,15 +33,15 @@ class TestWriteObj:
         """Test Writer.write_obj with little endian byte order."""
         with tempfile.NamedTemporaryFile(delete=False, suffix=".obj") as f:
             filename = f.name
-        
+
         try:
             # Binary string "0000000100000000" (value 256)
             binaries = ["0000000100000000"]
             Writer.write_obj(filename, binaries, byteorder="little")
-            
+
             with open(filename, "rb") as f:
                 data = f.read()
-            
+
             # Should be 2 bytes: 0x00 0x01 in little endian
             assert len(data) == 2
             assert data == b"\x00\x01"
@@ -53,7 +53,7 @@ class TestWriteObj:
         """Test Writer.write_obj with multiple binary values."""
         with tempfile.NamedTemporaryFile(delete=False, suffix=".obj") as f:
             filename = f.name
-        
+
         try:
             binaries = [
                 "0000000000000001",  # 1
@@ -61,10 +61,10 @@ class TestWriteObj:
                 "1111111111111111",  # 65535 (0xFFFF)
             ]
             Writer.write_obj(filename, binaries, byteorder="big")
-            
+
             with open(filename, "rb") as f:
                 data = f.read()
-            
+
             # Should be 6 bytes total (3 * 2)
             assert len(data) == 6
             assert data == b"\x00\x01\x00\x02\xff\xff"
@@ -80,14 +80,14 @@ class TestWriteTxt:
         """Test Writer.write_txt with simple lines."""
         with tempfile.NamedTemporaryFile(delete=False, suffix=".txt") as f:
             filename = f.name
-        
+
         try:
             lines = ["Line 1\n", "Line 2\n", "Line 3\n"]
             Writer.write_txt(filename, lines)
-            
+
             with open(filename, "r", encoding="utf-8") as f:
                 content = f.read()
-            
+
             assert content == "Line 1\nLine 2\nLine 3\n"
         finally:
             if os.path.exists(filename):
@@ -97,13 +97,13 @@ class TestWriteTxt:
         """Test Writer.write_txt with empty list."""
         with tempfile.NamedTemporaryFile(delete=False, suffix=".txt") as f:
             filename = f.name
-        
+
         try:
             Writer.write_txt(filename, [])
-            
+
             with open(filename, "r", encoding="utf-8") as f:
                 content = f.read()
-            
+
             assert content == ""
         finally:
             if os.path.exists(filename):
@@ -121,16 +121,16 @@ class TestSymbolFileGeneration:
             "LOOP": {"address": 0x3005, "line": 3},
             "MSG": {"address": 0x3010, "line": 5},
         }
-        
+
         # Generate symbol lines using the same logic as assembler.main
         sym_lines = [
-            f"{label:20}{' ':10}x{meta['address']:04X}\n" 
+            f"{label:20}{' ':10}x{meta['address']:04X}\n"
             for label, meta in symbols_table.items()
         ]
-        
+
         # Check that all lines are generated
         assert len(sym_lines) == 3
-        
+
         # Check format: label should be padded to 20 chars, space padding 10 chars, then address
         for line in sym_lines:
             parts = line.strip().split()
@@ -144,16 +144,16 @@ class TestSymbolFileGeneration:
         # This test ensures the fix to the f-string is correct
         # The previous format f"{label:20}{'':10}" would raise SyntaxError
         # The corrected format is f"{label:20}{' ':10}"
-        
+
         symbols_table = {
             "LABEL1": {"address": 0x3000, "line": 1},
         }
-        
+
         # This should not raise SyntaxError
         sym_lines = [
-            f"{label:20}{' ':10}x{meta['address']:04X}\n" 
+            f"{label:20}{' ':10}x{meta['address']:04X}\n"
             for label, meta in symbols_table.items()
         ]
-        
+
         assert len(sym_lines) == 1
         assert "x3000" in sym_lines[0]

--- a/assembler/writer.py
+++ b/assembler/writer.py
@@ -1,4 +1,7 @@
-"""Writer module for assembler output files."""
+"""Writer module for assembler output files.
+
+Handles low-level I/O operations only. Formatting is delegated to presenters.
+"""
 
 
 class Writer:
@@ -28,51 +31,3 @@ class Writer:
         with open(filename, "w", encoding="utf-8") as file:
             file.writelines(data)
 
-    @staticmethod
-    def build_listing(lines, stmts, symbols_table):
-        """Build a listing table from assembly lines, statements, and symbols.
-        
-        Args:
-            lines: Original assembly source lines
-            stmts: List of parsed statements
-            symbols_table: Dictionary of symbols with addresses
-            
-        Returns:
-            List of formatted listing lines
-        """
-        # invert symbols to address -> label for listing
-        addr_to_label = {f"x{v['address']:04X}": k for k, v in symbols_table.items()}
-
-        table = [["ADDR", "HEX", "BINARY", "LABEL", "LINE", "CODE"]]
-        stmt_idx = 0
-
-        for idx, line in enumerate(lines):
-            line_num = idx + 1
-
-            stmt = None
-            if stmt_idx < len(stmts) and stmts[stmt_idx].line == line_num:
-                stmt = stmts[stmt_idx]
-
-            addr = f"x{stmt.addr:04X}" if stmt and stmt.addr is not None else ""
-
-            binary = stmt.resolve() if stmt else ""
-            long_binary = isinstance(binary, list)
-            rest = []
-            if long_binary:
-                binary, *rest = binary
-
-            hexa = f"x{int(binary, 2):04X}" if binary else ""
-            label = addr_to_label.get(addr, "")
-
-            if stmt:
-                stmt_idx += 1
-
-            table.append([addr, hexa, binary, label, line_num, line])
-
-            if long_binary and stmt and stmt.addr is not None:
-                a = stmt.addr + 1
-                for b in rest:
-                    table.append([f"x{int(a):04X}", f"x{int(b, 2):04X}", b, "", "", ""])
-                    a += 1
-
-        return ["{0:6}| {1:6}| {2:16}| {3:20}| {4:4}| {5:}\n".format(*row) for row in table]

--- a/assembler/writer.py
+++ b/assembler/writer.py
@@ -1,6 +1,6 @@
 """Writer module for assembler output files.
 
-Handles low-level I/O operations only. Formatting is delegated to presenters.
+Handles low-level I/O operations only. Formatting is delegated to formatters.
 """
 
 

--- a/assembler/writer.py
+++ b/assembler/writer.py
@@ -10,7 +10,7 @@ class Writer:
     @staticmethod
     def write_obj(filename, binaries, byteorder="big"):
         """Write binary values to an object file in binary format.
-        
+
         Args:
             filename: Path to output .obj file
             binaries: List of binary strings (e.g., "0000000000000001")
@@ -23,7 +23,7 @@ class Writer:
     @staticmethod
     def write_txt(filename, data):
         """Write text data to a file.
-        
+
         Args:
             filename: Path to output text file
             data: List of strings to write


### PR DESCRIPTION
# Description

This PR closes #14 and #15 by:
- Refactor output by adding a `Formatters` module to manage different output formats.
- Refactor `pre_parsers` by splitting responsabilities into pure functions.
- Remove trailing whitespaces (yeah I know, probably shouldn't do this here :grin: )